### PR TITLE
Using vercel headers rather than CORS domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 // Imports
 require('dotenv').config();
 const express = require('express');
-const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const mongoSanitize = require('express-mongo-sanitize');
 const rateLimit = require("express-rate-limit");
@@ -12,11 +11,17 @@ const database = require('./modules/Database');
 /*
   Middleware Settings
 */
-const allowedOrigins = {
-  credentials: true, 
-  origin: process.env.FRONTEND_ADDRESS
-  // origin: isProduction ? "https://st-events.vercel.app" : "http://localhost:3000"
+
+const allowVercelRequests = (req, res, next) => {
+  const deploymentUrl = req.get('x-vercel-deployment-url');
+  console.log(deploymentUrl);
+  console.log(req.get('Origin'));
+  if (deploymentUrl === 'https://st-events.vercel.app') {
+    res.setHeader('Access-Control-Allow-Origin', req.get('Origin'));
+  }
+  next();
 };
+
 
 // const limiter = rateLimit({
 //   windowMs: 60 * 1000, // 1 minute
@@ -34,7 +39,7 @@ const app = express();
 
 // Rate-Limiting
 // app.use(limiter);
-app.use(cors(allowedOrigins)); // allows cross-origin-requests, letting frontend access this
+app.use(allowVercelRequests);
 app.use(express.urlencoded({ extended: false })); // parses body (p1)
 app.use(express.json()); // parses body (p2)
 app.use(cookieParser()); // parses cookies

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "axios": "^1.4.0",
     "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.6",
-    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-mongo-sanitize": "^2.2.0",


### PR DESCRIPTION
Vercel automatically sends an x-vercel-deployment-url, which allows us to allow sites using that header to access the backend. This fixes the problem where frontend previews/other branch previews could not access the backend because it was only setup to allow the main url.